### PR TITLE
Add: table for all-contributors bot.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,18 @@
 
 If you are working on your first pull request, check out the free series [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github), and/or the repo [First Contributions](https://github.com/rohitkrishna094/first-contributions).
 
-## Contributers list: 
+## Contributors ✨
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
-- @zurda
-- [@mrassili](https://github.com/mrassili)
-- [@luisduenas](https://github.com/luisduenas)
-- [@decarbonite](https://github.com/decarbonite)
-- [@Wgil](https://github.com/Wgil)
-- [@ksenousi](https://github.com/ksenousi)
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+  </tr>
+</table>
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
I added a section (table) where the `@all-contributors` bot will insert the contributors info.

Now we need to use (commenting pull requests or issues):
 `@all-contributors please add @nickname for code` <- `code` is just an example.
These are types of contributions available here: https://allcontributors.org/docs/en/emoji-key

Apart from that, the bot will create a JSON file named .all-contributorsrc, where before merging it with the changes,
for the `  "files": "README.md" ` part, README.md needs to be exchanged with the proper file name `CONTRIBUTING.md`,
where I prepared a table layout to avoid troubles I had on my forked repo.

Issue: #80